### PR TITLE
go.mod: add missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine AS builder
+FROM golang:1.11-alpine AS builder
 MAINTAINER huaqiao zhang <huaqiaoz@vmware.com>
 
 WORKDIR /go/src/github.com/edgexfoundry/edgex-ui-go
@@ -8,12 +8,12 @@ RUN echo "https://mirrors.ustc.edu.cn/alpine/v3.6/main" > /etc/apk/repositories
 RUN echo "https://mirrors.ustc.edu.cn/alpine/v3.6/community" >> /etc/apk/repositories
 RUN cat /etc/apk/repositories
 
-RUN apk update && apk add git make glide
+RUN apk update && apk add git make
 
 COPY . .
 
 RUN make prepare
-RUN make cmd/edgex-ui-go/edgex-ui-go
+RUN make cmd/edgex-ui-server/edgex-ui-server
 
 FROM alpine:3.6
 
@@ -21,6 +21,6 @@ EXPOSE 4000
 
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-ui-go/ /go/src/github.com/edgexfoundry/edgex-ui-go/
 
-WORKDIR /go/src/github.com/edgexfoundry/edgex-ui-go/cmd/edgex-ui-go
+WORKDIR /go/src/github.com/edgexfoundry/edgex-ui-go/cmd/edgex-ui-server
 
-ENTRYPOINT ["./edgex-ui-go"]
+ENTRYPOINT ["./edgex-ui-server"]

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ run:
 docker: $(DOCKERS)
 
 docker_edgex_ui_go:
-	docker build -f docker-file/Dockerfile --label "git_sha=$(GIT_SHA)" -t edgexfoundry/docker-edgex-ui-go:$(VERSION) .
+	docker build --label "git_sha=$(GIT_SHA)" -t edgexfoundry/docker-edgex-ui-go:$(VERSION) .

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 
 .PHONY: build clean test run docker
 
-GO=CGO_ENABLED=0 go
-GOCGO=CGO_ENABLED=1 go
+GO=CGO_ENABLED=0 GO111MODULE=on go
+GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 
 MICROSERVICES=cmd/edgex-ui-server/edgex-ui-server
 .PHONY: $(MICROSERVICES)
@@ -22,7 +22,7 @@ GOFLAGS=-ldflags "-X github.com/edgexfoundry/edgex-ui-go.Version=$(VERSION)"
 GIT_SHA=$(shell git rev-parse HEAD)
 
 build: $(MICROSERVICES)
-	go build ./...
+	$(GO) build ./...
 
 cmd/edgex-ui-server/edgex-ui-server:
 	$(GO) build $(GOFLAGS) -o $@ ./cmd/edgex-ui-server
@@ -31,8 +31,8 @@ clean:
 	rm -f $(MICROSERVICES)
 
 test:
-	go test -cover ./...
-	go vet ./...
+	GO111MODULE=on go test -cover ./...
+	GO111MODULE=on go vet ./...
 
 prepare:
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/gorilla/mux v1.7.1
 	github.com/gorilla/websocket v1.4.0
+	github.com/kr/pretty v0.1.0 // indirect
 	golang.org/x/net v0.0.0-20190419010253-1f3472d942ba // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
These dependencies were missing from the go.mod that was checked in.

Hopefully with these added, the jenkins jobs will be able to pass.

Fixes #81