### PR TITLE
Backports edgex-ui-go from Go 1.12 to Go 1.11.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgexfoundry/edgex-ui-go
 
-go 1.12
+go 1.11
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
The rest of edgex foundry is currently using Go 1.11.
Edgex-ui-go being on Go 1.12 makes is hard to run both the
main edgex services and edgex-ui-go from source. 

Signed-off-by: Alexandre Courouble <acourouble@vmware.com>