### PR TITLE
Add initial snap packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ vendor
 go.sum
 *.DS_Store
 cmd/edgex-ui-server/edgex-ui-server
+
+*.snap
+prime/
+squashfs-root/

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# get the values of $SNAP_DATA and $SNAP using the current symlink instead of
+# the default behavior which has the revision hard-coded, which breaks after
+# a refresh
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
+
+# install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
+# into $SNAP_DATA/config
+mkdir -p "$SNAP_DATA/config"
+if [ ! -f "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml" ]; then
+    mkdir -p "$SNAP_DATA/config/edgex-ui-server/res"
+    cp "$SNAP/config/edgex-ui-server/res/configuration.toml" \
+        "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml"
+    # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON env vars in the
+    # config file
+    sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+        -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+        -e "s@\$SNAP@$SNAP_CURRENT@g" \
+        "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml"
+fi

--- a/snap/local/runtime-helpers/bin/edgex-ui-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/edgex-ui-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# go into the $SNAP_DATA folder before executing the server because it doesn't
+# currently allow specifying a different location for the configuration file,
+# and as such we want to use the writable version of the config file in 
+# $SNAP_DATA 
+# also see https://github.com/edgexfoundry/edgex-ui-go/issues/111 for more 
+# details and upstream issue status
+cd "$SNAP_DATA/config/edgex-ui-server"
+
+exec "$SNAP/bin/edgex-ui-server"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,85 @@
+name: edgex-ui-go
+version: "replace-me"
+version-script: |
+  echo $(cat VERSION)-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+summary: EdgeX Web management UI
+base: core18
+description: |
+  The EdgeX Web management UI allows for a user to manage their EdgeX instance
+  using a web browser, adding devices, device profiles, as well as visualizing
+  data sent through the export services.
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: armhf
+  - build-on: arm64
+  - build-on: amd64
+  - build-on: i386
+
+apps:
+  edgex-ui-go:
+    command: bin/edgex-ui-wrapper.sh
+    daemon: simple
+    restart-condition: always
+    plugs:
+      - network
+      - network-bind
+
+parts:
+  web-static:
+    plugin: dump
+    source: cmd/edgex-ui-server
+    prime: 
+      - static/*
+  local-snap-assets:
+    plugin: dump
+    source: snap/local/runtime-helpers
+    prime:
+      - bin/*
+  go:
+    plugin: nil
+    source: snap/local/build-helpers
+    build-packages: [git, build-essential, curl] 
+    override-build: |
+      # use dpkg architecture to figure out our target arch
+      # note - we specifically don't use arch
+      case "$(dpkg --print-architecture)" in
+        amd64)
+          FILE_NAME=go1.11.9.linux-amd64.tar.gz
+          FILE_HASH=e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608
+          ;;
+        arm64)
+          FILE_NAME=go1.11.9.linux-arm64.tar.gz
+          FILE_HASH=892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05
+          ;;
+        armhf)
+          FILE_NAME=go1.11.9.linux-armv6l.tar.gz
+          FILE_HASH=f0d7b039cae61efdc346669f3459460e3dc03b6c6de528ca107fc53970cba0d1
+          ;;
+        i386)
+          FILE_NAME=go1.11.9.linux-386.tar.gz
+          FILE_HASH=0fa4001fcf1ef0644e261bf6dde02fc9f10ae4df6d74fda61fc4d3c3cbef1d79
+          ;;
+      esac
+      # download the archive, failing on ssl cert problems
+      curl https://dl.google.com/go/$FILE_NAME -O
+      echo "$FILE_HASH $FILE_NAME" > sha256
+      sha256sum -c sha256 | grep OK
+      tar -C $SNAPCRAFT_STAGE -xf go*.tar.gz --strip-components=1
+    prime:
+      - "-*"
+  edgex-ui-go:
+    after: [go]
+    source: .
+    plugin: make
+    override-build: |
+      make build
+      mkdir -p "$SNAPCRAFT_PART_INSTALL/bin"
+      mkdir -p "$SNAPCRAFT_PART_INSTALL/config/edgex-ui-server/res"
+      cp cmd/edgex-ui-server/edgex-ui-server $SNAPCRAFT_PART_INSTALL/bin/edgex-ui-server
+      # change the StaticResourcesPath to point to $SNAP
+      cat "./cmd/edgex-ui-server/res/configuration.toml" | \
+        sed -e s@"StaticResourcesPath = \"./static\""@"StaticResourcesPath = \"\$SNAP/static\""@ > \
+       "$SNAPCRAFT_PART_INSTALL/config/edgex-ui-server/res/configuration.toml"


### PR DESCRIPTION
Fixes #110 

The ci-management PR has been merged, so this PR is now ready for review. To test the snap, first [install snapd support](https://docs.snapcraft.io/installing-snapd) on a Linux machine, then install snapcraft with `snap install snapcraft --classic` and build this repo:

```bash
$ git clone https://github.com/anonymouse64/edgex-ui-go.git --branch feature/snap
$ cd edgex-ui-go
$ snapcraft
```

You should get a file named `edgex-ui-go*.snap`, install that file locally with:

```bash
$ sudo snap install --dangerous edgex-ui-go*.snap
```

Then you can test out an EdgeX installation as you normally would by visiting `localhost:4000` in a web browser on the machine.