### PR TITLE
ci: update local docker image names in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ run:
 docker: $(DOCKERS)
 
 docker_edgex_ui_go:
-	docker build --label "git_sha=$(GIT_SHA)" -t edgexfoundry/docker-edgex-ui-go:$(VERSION) .
+	docker build --label "git_sha=$(GIT_SHA)" -t edgexfoundry/edgex-ui:$(VERSION) .


### PR DESCRIPTION
As part of the Ireland release it was decided to remove the docker- in the image prefix and -go in the image suffix.