### PR TITLE
Update add-device.component.ts

### DIFF
--- a/web/src/app/metadata/device/add-device/add-device.component.ts
+++ b/web/src/app/metadata/device/add-device/add-device.component.ts
@@ -32,7 +32,7 @@ class MqttProtocolTemplate {
   User: string = "";
   Password: string = "";
   ClientId: string = "";
-  Topic: string = "";
+  CommandTopic: string = "";
 }
 
 class ModusTCPProtocolTemplate {


### PR DESCRIPTION
Fix a bug concerned with MQTT CommandTopic (previously Topic). This would cause error log: 'app=$device_name source=executor.go:54 msg="AutoEvent - error occurs when reading resource message: error reading DeviceResourece message for $device_name -> 'CommandTopic' not found in the 'mqtt' protocol properties"'

## PR Checklist
Please check if your PR fulfills the following requirements:

- [. ] Tests for the changes have been added (for bug fixes / features)
- [. ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
When you add a MQTT device, the device service would cause error log: 'app=$device_name source=executor.go:54 msg="AutoEvent - error occurs when reading resource message: error reading DeviceResourece message for $device_name -> 'CommandTopic' not found in the 'mqtt' protocol properties"'

## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [. ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ .] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information