### PR TITLE
fix(snap): set snap version using git tags

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: edgex-ui
-base: core18 
+base: core20 
 type: app
-adopt-info: version
+adopt-info: edgex-ui
 summary: A graphical user interface for EdgeX Foundry 
 description: |
   The EdgeX UI is for demonstration and developer use 
@@ -28,22 +28,6 @@ apps:
       - network-bind
 
 parts:
-  version:
-    plugin: nil
-    # we need to include git, in case we are building the minimal-snap-build
-    build-packages:
-      - git
-    # as with static-packages part, the source dir is unrelated to this part and is used
-    # since it changes rarely and therefore will not trigger a new pull
-    source: snap/local/runtime-helpers
-    override-pull: |
-      cd $SNAPCRAFT_PROJECT_DIR
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
-      
   web-static:
     plugin: dump
     source: cmd/edgex-ui-server
@@ -70,7 +54,8 @@ parts:
       if [ -z "$GIT_VERSION" ]; then
         GIT_VERSION="0.0.0"
       fi
-
+      
+      snapcraftctl set-version ${GIT_VERSION}
       echo $GIT_VERSION > ./VERSION
       
       [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -83,4 +68,4 @@ parts:
       cat "./cmd/edgex-ui-server/res/configuration.toml" | \
         sed -e s@"StaticResourcesPath = \"./static\""@"StaticResourcesPath = \"\$SNAP/static\""@ > \
        "$SNAPCRAFT_PART_INSTALL/config/edgex-ui-server/res/configuration.toml"
-
+       

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: edgex-ui
 base: core18 
 type: app
-version: '1.0'
+adopt-info: version
 summary: A graphical user interface for EdgeX Foundry 
 description: |
   The EdgeX UI is for demonstration and developer use 
@@ -28,6 +28,22 @@ apps:
       - network-bind
 
 parts:
+  version:
+    plugin: nil
+    # we need to include git, in case we are building the minimal-snap-build
+    build-packages:
+      - git
+    # as with static-packages part, the source dir is unrelated to this part and is used
+    # since it changes rarely and therefore will not trigger a new pull
+    source: snap/local/runtime-helpers
+    override-pull: |
+      cd $SNAPCRAFT_PROJECT_DIR
+      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
+      snapcraftctl set-version ${GIT_VERSION}
+      
   web-static:
     plugin: dump
     source: cmd/edgex-ui-server
@@ -49,6 +65,16 @@ parts:
     stage-packages: [libzmq5]
     override-build: |
       go mod tidy
+
+      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
+
+      echo $GIT_VERSION > ./VERSION
+      
+      [ ! -d "vendor" ] && go mod download all || echo "skipping..."
+
       make build
       mkdir -p "$SNAPCRAFT_PART_INSTALL/bin"
       mkdir -p "$SNAPCRAFT_PART_INSTALL/config/edgex-ui-server/res"

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "bootstrap": "^4.5.3",
     "cbor-js": "^0.1.0",
     "codemirror": "^5.62.3",
-    "echarts": "^5.2.0",
+    "echarts": "^5.2.1",
     "flatpickr": "^4.6.9",
     "font-awesome": "^4.7.0",
     "jquery": "^3.6.0",


### PR DESCRIPTION
update snapcraft.yaml for using git tags to set the version

resolve: #454

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
### Snap version test guideline:
##### Download edgex-ui and snapcraft it:
```
$ git clone https://github.com/MonicaisHer/edgex-ui-go.git
$ cd edgex-ui-go
$ git checkout fix-snap-version
$ snap install snapcraft
$ sudo snap install multipass
$ cd /edgex-ui-go  
$ snapcraft 
```

About 4 minutes, we should see:

```
Snapped edgex-ui_2.0.1-dev.11_amd64.snap
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->