### PR TITLE
fix: bug about invalid property type of rule

### DIFF
--- a/web/src/app/rule-engine/rules/rule-advanced-options/rule-advanced-options.component.html
+++ b/web/src/app/rule-engine/rules/rule-advanced-options/rule-advanced-options.component.html
@@ -35,8 +35,8 @@
                 </label>
                 <div class="col-sm-9">
                     <select class="custom-select" name="isEventTime" [(ngModel)]="ruleOptions.isEventTime">
-                        <option value="false">false</option>
-                        <option value="true">true</option>
+                        <option [ngValue]="false">false</option>
+                        <option [ngValue]="true">true</option>
                     </select>
                 </div>
             </div>
@@ -102,8 +102,8 @@
                 </label>
                 <div class="col-sm-9">
                     <select class="custom-select" name="sendMetaToSink" [(ngModel)]="ruleOptions.sendMetaToSink">
-                        <option value="false">false</option>
-                        <option value="true">true</option>
+                        <option [ngValue]="false">false</option>
+                        <option [ngValue]="true">true</option>
                     </select>
                 </div>
             </div>
@@ -115,8 +115,8 @@
                 </label>
                 <div class="col-sm-9">
                     <select class="custom-select" name="sendError" [(ngModel)]="ruleOptions.sendError">
-                        <option value="false">false</option>
-                        <option value="true">true</option>
+                        <option [ngValue]="false">false</option>
+                        <option [ngValue]="true">true</option>
                     </select>
                 </div>
             </div>

--- a/web/src/app/rule-engine/rules/rule-advanced-options/rule-advanced-options.component.ts
+++ b/web/src/app/rule-engine/rules/rule-advanced-options/rule-advanced-options.component.ts
@@ -34,7 +34,7 @@ export class RuleAdvancedOptionsComponent implements OnInit, OnChanges {
 
   constructor() { 
     this._ruleOptions = {
-      isEventTime: false,
+        isEventTime: false,
         sendMetaToSink: false,
         sendError: true,
         qos: 0

--- a/web/src/app/rule-engine/rules/sinks/mqtt-sink/mqtt-sink.component.html
+++ b/web/src/app/rule-engine/rules/sinks/mqtt-sink/mqtt-sink.component.html
@@ -82,8 +82,8 @@
                 <label class="col-sm-3 col-form-label text-nowrap text-truncate">Retained</label>
                 <div class="col-sm-9">
                     <select class="custom-select"  name="retained" [(ngModel)]="mqttSink.retained">
-                        <option value="false">false</option>
-                        <option value="true">true</option>
+                        <option [ngValue]="false">false</option>
+                        <option [ngValue]="true">true</option>
                     </select>
                 </div>
             </div>
@@ -121,8 +121,8 @@
                 <label class="col-sm-3 col-form-label text-nowrap text-truncate">InsecureSkipVerify</label>
                 <div class="col-sm-9">
                     <select class="custom-select"  name="insecureSkipVerify" [(ngModel)]="mqttSink.insecureSkipVerify">
-                        <option value="true">true</option>
-                        <option value="false">false</option>
+                        <option [ngValue]="true">true</option>
+                        <option [ngValue]="false">false</option>
                     </select>
                 </div>
             </div>

--- a/web/src/app/rule-engine/rules/sinks/nop-sink/nop-sink.component.html
+++ b/web/src/app/rule-engine/rules/sinks/nop-sink/nop-sink.component.html
@@ -31,8 +31,8 @@
                 </label>
                 <div class="col-sm-9">
                     <select class="custom-select"  name="log" [(ngModel)]="nopSink.log">
-                        <option value="false">false</option>
-                        <option value="true">true</option>
+                        <option [ngValue]="false">false</option>
+                        <option [ngValue]="true">true</option>
                     </select>
                 </div>
             </div>

--- a/web/src/app/rule-engine/rules/sinks/rest-sink/rest-sink.component.html
+++ b/web/src/app/rule-engine/rules/sinks/rest-sink/rest-sink.component.html
@@ -130,8 +130,8 @@
                     </label>
                     <div class="col-sm-9">
                         <select class="custom-select"  name="debugResp" [(ngModel)]="restSink.debugResp">
-                            <option value="false">false</option>
-                            <option value="true">true</option>
+                            <option [ngValue]="false">false</option>
+                            <option [ngValue]="true">true</option>
                         </select>
                     </div>
                 </div>
@@ -168,8 +168,8 @@
                     <label class="col-sm-3 col-form-label text-nowrap text-truncate">InsecureSkipVerify</label>
                     <div class="col-sm-9">
                         <select class="custom-select"  name="insecureSkipVerify" [(ngModel)]="restSink.insecureSkipVerify">
-                            <option value="true">true</option>
-                            <option value="false">false</option>
+                            <option [ngValue]="true">true</option>
+                            <option [ngValue]="false">false</option>
                         </select>
                     </div>
                 </div>

--- a/web/src/app/rule-engine/rules/sinks/sink-list/sink-list.component.html
+++ b/web/src/app/rule-engine/rules/sinks/sink-list/sink-list.component.html
@@ -61,7 +61,6 @@
                         <option value="{{MQTT_SINK}}">{{MQTT_SINK}}</option>
                         <option value="{{REST_SINK}}">{{REST_SINK}}</option>
                         <option value="{{LOG_SINK}}">{{LOG_SINK}}</option>
-                        <option value="{{NOP_SINK}}">{{NOP_SINK}}</option>
                     </select>
                     <div id="validationSinkTypeFeedback" class="invalid-feedback">
                         <small i18n>please select a valid Sink Type !</small>
@@ -78,9 +77,6 @@
             </div>
             <div *ngSwitchCase="REST_SINK">
                 <app-rest-sink [(restSink)]="restSink"></app-rest-sink>
-            </div>
-            <div *ngSwitchCase="NOP_SINK">
-                <app-nop-sink [(nopSink)]="nopSink"></app-nop-sink>
             </div>
             <div  *ngSwitchCase="LOG_SINK">
                 <app-log-sink [(logSink)]="logSink"></app-log-sink>


### PR DESCRIPTION
- fix invalid type of rule property, it's should be boolean not string.
- kuiper team ask to remove the nop sink.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->