### PR TITLE
build(snap): source metadata from central repo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,9 @@
 name: edgex-ui
 base: core20 
 type: app
-adopt-info: edgex-ui
-summary: A graphical user interface for EdgeX Foundry 
-description: |
-  The EdgeX UI is for demonstration and developer use 
-  to manage and monitor a single instance of EdgeX Foundry
-
+adopt-info: metadata
 grade: stable
 confinement: strict
-
-icon: snap/local/assets/edgex-snap-icon.png
 
 epoch: 1
 
@@ -41,6 +34,7 @@ parts:
       - bin/*
 
   edgex-ui:
+    after: [metadata]
     source: .
     plugin: make
     build-packages: [git, libzmq3-dev, zip, pkg-config]
@@ -50,14 +44,9 @@ parts:
     override-build: |
       go mod tidy
 
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      
-      snapcraftctl set-version ${GIT_VERSION}
-      echo $GIT_VERSION > ./VERSION
-      
+      # the version is needed for the build
+      cat ./VERSION
+
       [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
       make build
@@ -69,3 +58,27 @@ parts:
         sed -e s@"StaticResourcesPath = \"./static\""@"StaticResourcesPath = \"\$SNAP/static\""@ > \
        "$SNAPCRAFT_PART_INSTALL/config/edgex-ui-server/res/configuration.toml"
        
+  metadata:
+    plugin: nil
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+      
+      # change to this project's repo to get the version
+      cd $SNAPCRAFT_PROJECT_DIR
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+      # set the version of this snap
+      snapcraftctl set-version $VERSION
+    parse-info: [edgex-ui.metainfo.xml]   
+


### PR DESCRIPTION
The metadata kept in snapcraft.yaml is obsolete because it is being overridden on the store. This change will allow sourcing the central copy of metadata.

See https://github.com/canonical/edgex-snap-metadata/issues/2

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
# clean and build:
$ snapcraft clean && snapcraft

# unpack the built snap:
$ unsquashfs name.snap

# verify that icon exists:
$ ls squashfs-root/meta/gui/icon.png 
squashfs-root/meta/gui/icon.png

# verify that version, summary and description are included:
$ cat squashfs-root/meta/snap.yaml
...
name: edgex-ui
version: 2.0.1-dev.11
summary: EdgeX UI
description: |-
  EdgeX UI is a graphical user interface for EdgeX.
  It is intended for demonstration and development use to manage and monitor a
  single instance of EdgeX Foundry.

  For a command-line interface, see https://snapcraft.io/edgex-cli

  **Snap usage instructions**

  https://github.com/edgexfoundry/edgex-ui-go/blob/main/snap/README.md

  **Source code and more info**

  https://github.com/edgexfoundry/edgex-ui-go

  **Getting started**

  * v2.1: https://docs.edgexfoundry.org/2.1/getting-started/tools/Ch-GUI
  * v2.2: https://docs.edgexfoundry.org/2.2/getting-started/tools/Ch-GUI

  **EdgeX Documentation**

  https://docs.edgexfoundry.org

  **Reference platform snap**

  https://snapcraft.io/edgexfoundry
...
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->