### PR TITLE
fix: reset operationStatus when http call returns

### DIFF
--- a/web/src/app/rule-engine/rules/rules-list/rules-list.component.html
+++ b/web/src/app/rule-engine/rules/rules-list/rules-list.component.html
@@ -1,6 +1,7 @@
 <!--
 *******************************************************************************
  * Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+ * Copyright © 2022 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +20,7 @@
 <div class="card">
     <div class="card-header">
         <i class="fa fa-list text-danger mr-2"></i>
-        <span class="font-weight-bold" i18n>Rule List</span> 
+        <span class="font-weight-bold" i18n>Rule List</span>
     </div>
     <div class="card-header p-2">
         <div class="btn-group btn-group-sm" role="group">
@@ -80,9 +81,9 @@
                                 </div>
                             </span>
                             <span *ngIf="!operationStatus">
-                                <span role="button" class="badge badge-success mr-1" (click)="start(rule.id)" i18n>start</span>
-                                <span role="button" class="badge badge-info mr-1" (click)="restart(rule.id)" i18n>restart</span>
-                                <span role="button" class="badge badge-danger mr-1" (click)="stop(rule.id)" i18n>stop</span>
+                                <span role="button" class="badge badge-success mr-1" (click)="execute(rule.id, 'start')" i18n>start</span>
+                                <span role="button" class="badge badge-info mr-1" (click)="execute(rule.id, 'restart')" i18n>restart</span>
+                                <span role="button" class="badge badge-danger mr-1" (click)="execute(rule.id, 'stop')" i18n>stop</span>
                             </span>
                         </td>
                     </tr>
@@ -117,7 +118,7 @@
                 <h5 class="modal-title text-danger" id="deleteConfirmDialogLabel">
                     <i class="fa fa-warning mr-1"></i>
                     <span i18n>Warning</span>
-                </h5>  
+                </h5>
             </div>
             <div class="modal-body" i18n>
                 The data will be permanently erased!!! Are you sure to execute delete operation？

--- a/web/src/app/rule-engine/rules/rules-list/rules-list.component.ts
+++ b/web/src/app/rule-engine/rules/rules-list/rules-list.component.ts
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+ * Copyright © 2022 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,7 +11,7 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  * @author: Huaqiao Zhang, <huaqiaoz@vmware.com>
  *******************************************************************************/
 
@@ -95,7 +96,7 @@ export class RulesListComponent implements OnInit {
   deleteConfirm() {
     $("#deleteConfirmDialog").modal('show');
   }
-  
+
   delete() {
     this.selectedRules.forEach((ruleSelected,i) => {
       this.ruleSvc.deleteOneRuleById(ruleSelected.id).subscribe(() => {
@@ -159,36 +160,15 @@ export class RulesListComponent implements OnInit {
     }
   }
 
-  start(ruleID: string) {
+  execute(ruleID: string, command: string) {
     this.operationStatus = true
-    window.setTimeout(() => {
-      this.operationStatus = false
-    },1500)
-    this.ruleSvc.startRule(ruleID).subscribe(() => {
-      this.msgSvc.success(`start ${ruleID}`);
-      this.getRulesList();
-    })
-  }
-
-  stop(ruleID: string) {
-    this.operationStatus = true
-    window.setTimeout(() => {
-      this.operationStatus = false
-    },1500)
-    this.ruleSvc.stopRule(ruleID).subscribe(() => {
-      this.msgSvc.success(`stop ${ruleID}`);
-      this.getRulesList();
-    })
-  }
-
-  restart(ruleID: string) {
-    this.operationStatus = true
-    window.setTimeout(() => {
-      this.operationStatus = false
-    },1500)
-    this.ruleSvc.restartRule(ruleID).subscribe(() => {
-      this.msgSvc.success(`restart ${ruleID}`);
-      this.getRulesList();
+    this.ruleSvc.executeRuleCommand(ruleID, command).subscribe({
+      next: () => {
+        this.operationStatus = false;
+        this.msgSvc.success(`${command} ${ruleID}`);
+        this.getRulesList();
+      },
+      error: () => this.operationStatus = false
     })
   }
 }

--- a/web/src/app/services/rule-engine.service.ts
+++ b/web/src/app/services/rule-engine.service.ts
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+ * Copyright © 2022 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,7 +11,7 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  * @author: Huaqiao Zhang, <huaqiaoz@vmware.com>
  *******************************************************************************/
 
@@ -159,27 +160,11 @@ export class RuleEngineService {
     )
   }
 
-  startRule(id: string): Observable<string> {
-    let url = `${this.ruleUrl}/${id}/start`;
+  executeRuleCommand(id: string, command: string) {
+    let url = `${this.ruleUrl}/${id}/${command}`;
     return this.http.post(url,null,{responseType: 'text'})
-    .pipe(
-      catchError(error => this.errorSvc.handleError(error))
-    )
-  }
-
-  stopRule(id: string): Observable<string> {
-    let url = `${this.ruleUrl}/${id}/stop`;
-    return this.http.post(url,null,{responseType: 'text'})
-    .pipe(
-      catchError(error => this.errorSvc.handleError(error))
-    )
-  }
-
-  restartRule(id: string): Observable<string> {
-    let url = `${this.ruleUrl}/${id}/restart`;
-    return this.http.post(url,null,{responseType: 'text'})
-    .pipe(
-      catchError(error => this.errorSvc.handleError(error))
-    )
+      .pipe(
+        catchError(error => this.errorSvc.handleError(error))
+      )
   }
 }


### PR DESCRIPTION
- refactor and cleanup of rule start/stop/restart

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>


This fixes the hard-coded 1.5 second sleep that auto-resets the `operationStatus`, and updates it when the http post is completed.

> Note: this has not been tested

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>
