### PR TITLE
feat(snap): Support for snap options to set environment variables

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec $SNAP/bin/helper-go configure

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,22 +1,3 @@
 #!/bin/bash -e
 
-# get the values of $SNAP_DATA and $SNAP using the current symlink instead of
-# the default behavior which has the revision hard-coded, which breaks after
-# a refresh
-SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
-SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
-
-# install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
-# into $SNAP_DATA/config
-mkdir -p "$SNAP_DATA/config"
-if [ ! -f "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml" ]; then
-    mkdir -p "$SNAP_DATA/config/edgex-ui-server/res"
-    cp "$SNAP/config/edgex-ui-server/res/configuration.toml" \
-        "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml"
-    # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON env vars in the
-    # config file
-    sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
-        -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
-        -e "s@\$SNAP@$SNAP_CURRENT@g" \
-        "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml"
-fi
+exec $SNAP/bin/helper-go install

--- a/snap/local/bin/edgex-ui-wrapper.sh
+++ b/snap/local/bin/edgex-ui-wrapper.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
 
 cd "$SNAP"
+env
 exec ./bin/edgex-ui-server --conf "$SNAP_DATA/config/edgex-ui-server/res/configuration.toml"

--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+# convert cmdline to string array
+ARGV=($@)
+
+# grab binary path
+BINPATH="${ARGV[0]}"
+
+SERVICE="edgex-ui"
+SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+TAG="edgex-$SERVICE."$(basename "$0")
+
+if [ -f "$SERVICE_ENV" ]; then
+    logger --tag=$TAG "sourcing $SERVICE_ENV"
+    set -o allexport
+    source "$SERVICE_ENV" set
+    set +o allexport 
+fi
+
+exec "$@"

--- a/snap/local/helper-go/Makefile
+++ b/snap/local/helper-go/Makefile
@@ -1,0 +1,9 @@
+build:
+	go build -ldflags="-s -w" -o helper-go
+
+tidy:
+	go mod tidy
+
+clean:
+	rm -f helper-go
+

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
+	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
+)
+
+// configure is called by the main function
+func configure() {
+	const app = "edgex-ui"
+
+	log.SetComponentName("configure")
+
+	log.Info("Enabling config options")
+	err := snapctl.Set("app-options", "true").Run()
+	if err != nil {
+		log.Fatalf("Could not enable config options: %v", err)
+	}
+
+	log.Info("Processing config options")
+	err = options.ProcessConfig(app)
+	if err != nil {
+		log.Fatalf("Could not process config options: %v", err)
+	}
+
+	log.Info("Processing autostart options")
+	err = options.ProcessAutostart(app)
+	if err != nil {
+		log.Fatalf("Could not process autostart options: %v", err)
+	}
+
+}

--- a/snap/local/helper-go/go.mod
+++ b/snap/local/helper-go/go.mod
@@ -1,0 +1,5 @@
+module github.com/edgexfoundry/device-virtual-go/hooks
+
+go 1.18
+
+require github.com/canonical/edgex-snap-hooks/v2 v2.4.1

--- a/snap/local/helper-go/go.mod
+++ b/snap/local/helper-go/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-virtual-go/hooks
 
-go 1.18
+go 1.17
 
 require github.com/canonical/edgex-snap-hooks/v2 v2.4.1

--- a/snap/local/helper-go/go.sum
+++ b/snap/local/helper-go/go.sum
@@ -1,0 +1,16 @@
+github.com/canonical/edgex-snap-hooks/v2 v2.4.1 h1:TFFF/mHkYTmUd040N8S4q/mp78CUZr1W3Cxx4uRpfOg=
+github.com/canonical/edgex-snap-hooks/v2 v2.4.1/go.mod h1:8mjUKSAFNsXYvV0fcfOoYue1dSjTVeJYdaQYtA6pb6Y=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -10,23 +10,36 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  * SPDX-License-Identifier: Apache-2.0'
  */
 
 package main
 
 import (
-	"os"
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/env"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
 )
 
-func main() {
-	subCommand := os.Args[1]
-	switch subCommand {
-	case "install":
-		install()
-	case "configure":
-		configure()
-	default:
-		panic("Unknown subcommand: " + subCommand)
+func installConfig() error {
+	path := "/config/edgex-ui-server/res"
+
+	err := hooks.CopyDir(
+		env.Snap+path,
+		env.SnapData+path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func install() {
+	log.SetComponentName("install")
+
+	err := installConfig()
+	if err != nil {
+		log.Fatalf("Error installing config file: %s", err)
 	}
 }

--- a/snap/local/helper-go/main.go
+++ b/snap/local/helper-go/main.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	subCommand := os.Args[1]
+	switch subCommand {
+	// case "install":
+	// 	install()
+	case "configure":
+		configure()
+	default:
+		panic("Unknown subcommand: " + subCommand)
+	}
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,25 +13,37 @@ architectures:
 
 apps:
   edgex-ui:
+    command-chain:
+      - bin/source-env-file.sh
     command: bin/edgex-ui-wrapper.sh
     daemon: simple
-    restart-condition: always
+    install-mode: disable
     plugs:
       - network
       - network-bind
 
 parts:
+  helper-go:
+    source: snap/local/helper-go
+    plugin: make
+    build-snaps: [go/1.17/stable]
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+      make build
+      install -DT ./helper-go $SNAPCRAFT_PART_INSTALL/bin/helper-go
+  
   web-static:
     plugin: dump
     source: cmd/edgex-ui-server
     prime: 
        - static/web/*
-       
-  local-snap-assets:
+  
+  local-bin:
     plugin: dump
-    source: snap/local/runtime-helpers
-    prime:
-      - bin/*
+    source: snap/local/bin
+    organize:
+      source-env-file.sh: bin/source-env-file.sh
+      edgex-ui-wrapper.sh: bin/edgex-ui-wrapper.sh
 
   edgex-ui:
     after: [metadata]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,8 +42,6 @@ parts:
       - go/1.18/stable
     stage-packages: [libzmq5]
     override-build: |
-      go mod tidy
-
       # the version is needed for the build
       cat ./VERSION
 


### PR DESCRIPTION
This PR will add support for setting environment variables for the service, via snap options.

In addition:
- The install hook has been ported from bash to go (since the added configure hook is also in Go)
- The install mode is changed to `disable` which means the service no longer starts by default. This is needed to allow setting the environment variables before the service start, dropping the need for a manual restart. ~This change may be considered a breaking change and needs further investigation. In particular, need to test if an upgrade from an older version results in a stopped service or not.~

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix: https://github.com/canonical/edgex-snap-testing/pull/121
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change: https://github.com/edgexfoundry/edgex-docs/pull/868

## Testing Instructions
<!-- How can the reviewers test your change? -->

```bash
snap install edgex-ui --channel=latest/edge/pr-553
snap set edgex-ui config.edgex-security-secret-store=false
snap start edgex-ui

snap install edgexfoundry
snap set security-secret-store=off
```
Access http://localhost:4000

## New Dependency Instructions (If applicable)
The new dependency (`github.com/canonical/edgex-snap-hooks/v2`) has been approved in the past and used in other Go projects: 