### PR TITLE
feat!: Proxy hostname change from edgex-kong to edgex-nginx

### DIFF
--- a/cmd/edgex-ui-server/res/configuration.toml
+++ b/cmd/edgex-ui-server/res/configuration.toml
@@ -55,10 +55,7 @@ Type = "consul"
 ConfigRegistryStem="edgex/appservices/"
 ServiceVersion="2.0"
 
-[Kong]
+[APIGateway]
 Server = "localhost"
-AdminPort = 8001
-AdminPortSSL = 8444
 ApplicationPort = 8000
 ApplicationPortSSL = 8443
-StatusPort = 8100

--- a/cmd/edgex-ui-server/res/docker/configuration.toml
+++ b/cmd/edgex-ui-server/res/docker/configuration.toml
@@ -55,10 +55,7 @@ Type = "consul"
 ConfigRegistryStem="edgex/appservices/"
 ServiceVersion="2.0"
 
-[Kong]
-Server = "edgex-kong"
-AdminPort = 8001
-AdminPortSSL = 8444
+[APIGateway]
+Server = "edgex-nginx"
 ApplicationPort = 8000
 ApplicationPortSSL = 8443
-StatusPort = 8100

--- a/internal/application.go
+++ b/internal/application.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -99,7 +100,7 @@ func (app *Application) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *Application) secure(w http.ResponseWriter, r *http.Request) {
-	targetHost := fmt.Sprintf("%s:%d", app.config.Kong.Server, app.config.Kong.ApplicationPort)
+	targetHost := fmt.Sprintf("%s:%d", app.config.APIGateway.Server, app.config.APIGateway.ApplicationPort)
 	director := func(req *http.Request) {
 		req.URL.Scheme = HttpProtocol
 		req.URL.Host = targetHost

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,13 +23,10 @@ import (
 
 var defaultConfigFilePath = "res/configuration.toml"
 
-type KongInfo struct {
+type APIGatewayInfo struct {
 	Server             string
-	AdminPort          int
-	AdminPortSSL       int
 	ApplicationPort    int
 	ApplicationPortSSL int
-	StatusPort         int
 }
 
 type RegistryInfo struct {
@@ -38,11 +36,11 @@ type RegistryInfo struct {
 }
 
 type ConfigurationStruct struct {
-	Writable WritableInfo
-	Service  bootstrapConfig.ServiceInfo
-	Clients  map[string]bootstrapConfig.ClientInfo
-	Registry RegistryInfo
-	Kong     KongInfo
+	Writable   WritableInfo
+	Service    bootstrapConfig.ServiceInfo
+	Clients    map[string]bootstrapConfig.ClientInfo
+	Registry   RegistryInfo
+	APIGateway APIGatewayInfo
 }
 
 type WritableInfo struct {

--- a/internal/handler/registercenter.go
+++ b/internal/handler/registercenter.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -80,7 +81,7 @@ func (rh *ResourceHandler) getAclTokenOfConsul(w http.ResponseWriter, r *http.Re
 	config := container.ConfigurationFrom(rh.dic.Get)
 	var acl struct{ SecretID string }
 	client := &http.Client{}
-	url := fmt.Sprintf("http://%s:%d%s", config.Kong.Server, config.Kong.ApplicationPort, AclOfConsulPath)
+	url := fmt.Sprintf("http://%s:%d%s", config.APIGateway.Server, config.APIGateway.ApplicationPort, AclOfConsulPath)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", err, http.StatusInternalServerError


### PR DESCRIPTION
BREAKING CHANGE: Host name for API gateway change from edgex-kong to edgex-nginx.

Besides breaking change, a minor refactoring to remove references to Kong and replace with API gateway
and remove unused configuration fields. (Left in ApplicationPortSSL for now in case future versions of UI switch to TLS port.)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
This change is dependent on breaking changes in edgex-go and edgex-compose.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->