### PR TITLE
fix(snap): Upgrade env file path for v3 edgex-snap-hooks compatibility

### DIFF
--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,20 +1,16 @@
 #!/bin/bash -e
 
-# convert cmdline to string array
-ARGV=($@)
-
-# grab binary path
-BINPATH="${ARGV[0]}"
-
 SERVICE="edgex-ui"
-SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+ENV_FILE="$SNAP_DATA/config/$SERVICE/overrides.env"
 TAG="edgex-$SERVICE."$(basename "$0")
 
-if [ -f "$SERVICE_ENV" ]; then
-    logger --tag=$TAG "sourcing $SERVICE_ENV"
+if [ -f "$ENV_FILE" ]; then
+    logger --tag=$TAG "sourcing $ENV_FILE"
     set -o allexport
-    source "$SERVICE_ENV" set
+    source "$ENV_FILE" set
     set +o allexport 
+else
+    logger --tag=$TAG "$ENV_FILE not found!"
 fi
 
 exec "$@"


### PR DESCRIPTION
This is to fix the env file override capability via snap options which has gone broken since #607. 
The snap's edgex-snap-hooks Go dependency was upgraded in #607 which uses a new path for the env file. The path change was to avoid a conflict with snapped config provider directory in device/app services by moving the env file outside the read-only config provider directory.


<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->