### PR TITLE
fix: Use the AuthData from the incoming request for DeviceProfileClient

### DIFF
--- a/internal/handler/profile.go
+++ b/internal/handler/profile.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright © 2017-2018 VMware, Inc. All Rights Reserved.
+ * Copyright © 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,8 +25,6 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/edgex-ui-go/internal/container"
-	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
-	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
 	client "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
@@ -38,7 +37,6 @@ import (
 func (rh *ResourceHandler) AddProfileYamlContent(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	var profile dtos.DeviceProfile
-	jwtSecretProvider := secret.NewJWTSecretProvider(bootstrapContainer.SecretProviderExtFrom(rh.dic.Get))
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -53,7 +51,7 @@ func (rh *ResourceHandler) AddProfileYamlContent(w http.ResponseWriter, r *http.
 
 	config := container.ConfigurationFrom(rh.dic.Get)
 	url := fmt.Sprintf("%s://%s:%d", config.Clients[metadataSvcName].Protocol, config.Clients[metadataSvcName].Host, config.Clients[metadataSvcName].Port)
-	c := client.NewDeviceProfileClient(url, jwtSecretProvider, false)
+	c := client.NewDeviceProfileClient(url, newProfileAuthInjector(r), false)
 
 	profiles := []requests.DeviceProfileRequest{
 		{
@@ -75,11 +73,10 @@ func (rh *ResourceHandler) FindProfileAndConvertToYamlByName(w http.ResponseWrit
 	defer r.Body.Close()
 	vars := mux.Vars(r)
 	profileName := vars["name"]
-	jwtSecretProvider := secret.NewJWTSecretProvider(bootstrapContainer.SecretProviderExtFrom(rh.dic.Get))
 
 	config := container.ConfigurationFrom(rh.dic.Get)
 	url := fmt.Sprintf("%s://%s:%d", config.Clients[metadataSvcName].Protocol, config.Clients[metadataSvcName].Host, config.Clients[metadataSvcName].Port)
-	c := client.NewDeviceProfileClient(url, jwtSecretProvider, false)
+	c := client.NewDeviceProfileClient(url, newProfileAuthInjector(r), false)
 	var resp responses.DeviceProfileResponse
 	var err error
 	if resp, err = c.DeviceProfileByName(context.Background(), profileName); err != nil {
@@ -97,7 +94,6 @@ func (rh *ResourceHandler) FindProfileAndConvertToYamlByName(w http.ResponseWrit
 func (rh *ResourceHandler) UpdateProfileYamlContent(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	var profile dtos.DeviceProfile
-	jwtSecretProvider := secret.NewJWTSecretProvider(bootstrapContainer.SecretProviderExtFrom(rh.dic.Get))
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -112,7 +108,7 @@ func (rh *ResourceHandler) UpdateProfileYamlContent(w http.ResponseWriter, r *ht
 
 	config := container.ConfigurationFrom(rh.dic.Get)
 	url := fmt.Sprintf("%s://%s:%d", config.Clients[metadataSvcName].Protocol, config.Clients[metadataSvcName].Host, config.Clients[metadataSvcName].Port)
-	c := client.NewDeviceProfileClient(url, jwtSecretProvider, false)
+	c := client.NewDeviceProfileClient(url, newProfileAuthInjector(r), false)
 	profiles := []requests.DeviceProfileRequest{
 		{
 			BaseRequest: common.NewBaseRequest(),
@@ -128,4 +124,26 @@ func (rh *ResourceHandler) UpdateProfileYamlContent(w http.ResponseWriter, r *ht
 	result, _ := json.Marshal(resp)
 
 	w.Write(result)
+}
+
+// This AuthenticationInjector simply injects the Auth Data from the incoming request to the out going request
+type profileAuthInjector struct {
+	authData string
+}
+
+func newProfileAuthInjector(request *http.Request) *profileAuthInjector {
+	p := profileAuthInjector{
+		authData: request.Header.Get("Authorization"),
+	}
+
+	return &p
+}
+
+func (p *profileAuthInjector) AddAuthenticationData(request *http.Request) error {
+	if len(p.authData) == 0 {
+		return nil
+	}
+
+	request.Header.Add("Authorization", p.authData)
+	return nil
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run secure EdgeX stack with Device Virtual
```
make run ds-virtual
```
Get token for UI
```
make get-token
```
Browser to UI and enter token
Navigate to device profiles.
Click Add
Verify no error and blank editor is presented
Click Device Profile Tab and select a profile and click edit
Verify no error and profile is presented in the editor 
Change the description and click save
Verify nor error and success message displayed

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->