### PR TITLE
fix: add missing properties to ModusTCPProtocolTemplate class

### DIFF
--- a/web/src/app/metadata/device/device-protocol/builtin-protocol-template/types.ts
+++ b/web/src/app/metadata/device/device-protocol/builtin-protocol-template/types.ts
@@ -11,7 +11,7 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  * @author: Huaqiao Zhang, <huaqiaoz@vmware.com>
  *******************************************************************************/
 
@@ -31,6 +31,9 @@ export class ModusTCPProtocolTemplate {
   UnitID: string = "";
   Timeout: string = "";
   IdleTimeout: string = "";
+  LinkRecoveryTimeout: string = "";
+  ProtocolRecoveryTimeout: string = "";
+  ConnectDelay: string = "";
 }
 
 export class ModusRTUProtocolTemplate {


### PR DESCRIPTION
Linked to https://github.com/edgexfoundry/device-modbus-go/pull/688

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-ui-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) -> 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
 Already done

## Testing Instructions
Run `npm run start` in the web directory. Verify existence of new properties when registering TCP devices

## New Dependency Instructions (If applicable)
NA